### PR TITLE
Change `commandedvoltage_series` to be optional

### DIFF
--- a/spec/ndx-fiber-photometry.extensions.yaml
+++ b/spec/ndx-fiber-photometry.extensions.yaml
@@ -60,6 +60,7 @@ groups:
   - name: gain
     dtype: float
     doc: Gain on the photodetector.
+    required: false
 - neurodata_type_def: DichroicMirror
   neurodata_type_inc: Device
   doc: Extends Device to hold a Dichroic Mirror.
@@ -176,6 +177,7 @@ groups:
     - null
     - null
     doc: Link to the commanded voltage series.
+    quantity: '?'
   - name: photodetector
     neurodata_type_inc: VectorData
     dtype:

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -131,6 +131,7 @@ def main():
                 name="gain",
                 doc="Gain on the photodetector.",
                 dtype="float",
+                required=False,
             ),
         ],
     )
@@ -269,6 +270,7 @@ def main():
                 dtype=NWBRefSpec(target_type="TimeSeries", reftype="object"),
                 shape=(None, None),
                 neurodata_type_inc="VectorData",
+                quantity="?",
             ),
             NWBDatasetSpec(
                 name="photodetector",


### PR DESCRIPTION
Fixes #3 
- Changes `commandedvoltage_series` to be optional in `FiberPhotometryTable`
- Changes `gain` to be optional in `Photodetector`
