### PR TITLE
Allow `FiberPhotometryResponseSeries`  with 1D data

### DIFF
--- a/spec/ndx-fiber-photometry.extensions.yaml
+++ b/spec/ndx-fiber-photometry.extensions.yaml
@@ -251,8 +251,9 @@ groups:
   datasets:
   - name: data
     shape:
-    - null
-    - null
+    - - null
+    - - null
+      - null
     doc: The data values. May be 1D or 2D. The first dimension must be time.The optional
       second dimension refers to the fiber that record the series.
   - name: fiber_photometry_table_region

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -361,7 +361,7 @@ def main():
                 name="data",
                 doc="The data values. May be 1D or 2D. The first dimension must be time."
                 "The optional second dimension refers to the fiber that record the series.",
-                shape=(None, None),
+                shape=((None, ), (None, None)),
             ),
             NWBDatasetSpec(
                 name="fiber_photometry_table_region",


### PR DESCRIPTION
Fix #15 