### PR TITLE
Update ndx-ophys-devices version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.2.1 (Upcoming)
 
+* Updated requirements to depend on ndx-ophys-devices>=0.3.1 [PR #40](https://github.com/catalystneuro/ndx-fiber-photometry/pull/40)
+
 # v0.2.0 (September 18th, 2025)
 
 * Refactored the extension to depend on ndx-ophys-devices for device and biological component specification, replacing its previous standalone device types [PR #37](https://github.com/catalystneuro/ndx-fiber-photometry/pull/37).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 dependencies = [
     "pynwb>=3.1.0",
     "hdmf>=4.1.0",
-    "ndx_ophys_devices>=0.3.0",
+    "ndx_ophys_devices>=0.3.1",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,4 @@ pytest-subtests==0.12.1
 python-dateutil==2.8.2
 ruff==0.3.4
 tox==4.14.2
-ndx_ophys_devices==0.3.0
+ndx_ophys_devices==0.3.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,4 +3,4 @@
 # NOTE: it may be possible to relax these minimum requirements
 pynwb>=3.1.0
 hdmf>=4.1.0
-ndx_ophys_devices>=0.3.0
+ndx_ophys_devices>=0.3.1


### PR DESCRIPTION
This PR updates the dependency to use the latest version of ndx-ophys-devices (0.3.1) which fixes the namespace bug that I introduced previously with 0.3.0. For details, see https://github.com/catalystneuro/ndx-ophys-devices/pull/21